### PR TITLE
docs: Update key mapping examples to use <Leader>a

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The plugin provides `<Plug>` mappings that you can map to your preferred keys.
 
 Example configuration:
 ```vim
-nmap <Leader>cy <Plug>(send-to-ai-cli-yanked)
-nmap <Leader>cb <Plug>(send-to-ai-cli-buffer)
-vmap <Leader>cv <Plug>(send-to-ai-cli-visual)
+nmap <Leader>ay <Plug>(send-to-ai-cli-yanked)
+nmap <Leader>ab <Plug>(send-to-ai-cli-buffer)
+vmap <Leader>av <Plug>(send-to-ai-cli-visual)
 ```
 
 ### Commands
@@ -70,9 +70,9 @@ vmap <Leader>cv <Plug>(send-to-ai-cli-visual)
 ### Custom Mappings
 
 ```vim
-nmap <Leader>cy <Plug>(send-to-ai-cli-yanked)
-nmap <Leader>cb <Plug>(send-to-ai-cli-buffer)
-vmap <Leader>cv <Plug>(send-to-ai-cli-visual)
+nmap <Leader>ay <Plug>(send-to-ai-cli-yanked)
+nmap <Leader>ab <Plug>(send-to-ai-cli-buffer)
+vmap <Leader>av <Plug>(send-to-ai-cli-visual)
 ```
 
 ## Examples

--- a/doc/send_to_ai_cli.txt
+++ b/doc/send_to_ai_cli.txt
@@ -100,9 +100,9 @@ Example: >
 
 Default mappings (can be disabled with g:ai_cli_no_default_mappings):
 
-    <Space>cy    Send yanked text to AI CLI
-    <Space>cb    Send entire buffer to AI CLI
-    <Space>cv    Send visual selection to AI CLI (visual mode)
+    <Space>ay    Send yanked text to AI CLI
+    <Space>ab    Send entire buffer to AI CLI
+    <Space>av    Send visual selection to AI CLI (visual mode)
 
 Plug mappings for custom configuration:
 
@@ -123,9 +123,9 @@ Plug mappings for custom configuration:
 8. EXAMPLES                                        *send-to-ai-cli-examples*
 
 Custom mappings: >
-    nmap <Leader>cy <Plug>(send-to-ai-cli-yanked)
-    nmap <Leader>cb <Plug>(send-to-ai-cli-buffer)
-    vmap <Leader>cv <Plug>(send-to-ai-cli-visual)
+    nmap <Leader>ay <Plug>(send-to-ai-cli-yanked)
+    nmap <Leader>ab <Plug>(send-to-ai-cli-buffer)
+    vmap <Leader>av <Plug>(send-to-ai-cli-visual)
 <
 
 Fallback target configuration: >


### PR DESCRIPTION
This PR updates the key mapping examples in the README and documentation to use  instead of  to better reflect the plugin's name.