### PR TITLE
feat: send current paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Vim plugin that allows you to send text from Vim to a tmux pane running AI CLI
 - Send entire buffer to AI CLI
 - Send visual selection to AI CLI
 - Send specific line ranges to AI CLI
+- Send current line to AI CLI
+- Send current paragraph to AI CLI
 - Configurable tmux target pane
 
 ## Requirements
@@ -59,6 +61,8 @@ Example configuration:
 nmap <Leader>ay <Plug>(send-to-ai-cli-yanked)
 nmap <Leader>ab <Plug>(send-to-ai-cli-buffer)
 vmap <Leader>av <Plug>(send-to-ai-cli-visual)
+nmap <Leader>al <Plug>(send-to-ai-cli-current-line)
+nmap <Leader>ap <Plug>(send-to-ai-cli-paragraph)
 ```
 
 ### Commands
@@ -66,6 +70,8 @@ vmap <Leader>av <Plug>(send-to-ai-cli-visual)
 - `:AiCliSendYanked` - Send yanked text
 - `:AiCliSendBuffer` - Send entire buffer
 - `:[range]AiCliSendRange` - Send specific line range
+- `:AiCliSendCurrentLine` - Send current line
+- `:AiCliSendParagraph` - Send current paragraph
 
 ### Custom Mappings
 
@@ -73,6 +79,8 @@ vmap <Leader>av <Plug>(send-to-ai-cli-visual)
 nmap <Leader>ay <Plug>(send-to-ai-cli-yanked)
 nmap <Leader>ab <Plug>(send-to-ai-cli-buffer)
 vmap <Leader>av <Plug>(send-to-ai-cli-visual)
+nmap <Leader>al <Plug>(send-to-ai-cli-current-line)
+nmap <Leader>ap <Plug>(send-to-ai-cli-paragraph)
 ```
 
 ## Examples

--- a/autoload/send_to_ai_cli.vim
+++ b/autoload/send_to_ai_cli.vim
@@ -60,6 +60,44 @@ function! send_to_ai_cli#send_current_line() abort
   echo "Sent current line to AI CLI"
 endfunction
 
+function! send_to_ai_cli#send_paragraph() abort
+  let l:save_pos = getpos('.')
+  
+  " Find paragraph boundaries
+  let l:start_line = search('^$\|^\s*$', 'bnW') + 1
+  if l:start_line == 1 && getline(1) =~ '^\s*$'
+    let l:start_line = search('^\S', 'nW')
+  endif
+  if l:start_line == 0
+    let l:start_line = 1
+  endif
+  
+  let l:end_line = search('^$\|^\s*$', 'nW') - 1
+  if l:end_line < 0
+    let l:end_line = line('$')
+  endif
+  
+  " Make sure we include the current line
+  if l:start_line > line('.')
+    let l:start_line = line('.')
+  endif
+  if l:end_line < line('.')
+    let l:end_line = line('.')
+  endif
+  
+  let l:text = join(getline(l:start_line, l:end_line), "\n")
+  
+  call setpos('.', l:save_pos)
+  
+  if empty(l:text)
+    echo "No paragraph found"
+    return
+  endif
+
+  call s:send_text_to_ai_cli(l:text)
+  echo "Sent current paragraph to AI CLI"
+endfunction
+
 function! s:send_text_to_ai_cli(text) abort
   let l:target = s:find_ai_cli_pane()
   if empty(l:target)

--- a/autoload/send_to_ai_cli.vim
+++ b/autoload/send_to_ai_cli.vim
@@ -64,7 +64,7 @@ function! send_to_ai_cli#send_paragraph() abort
   let l:save_pos = getpos('.')
   
   " Find paragraph boundaries
-  let l:start_line = search('^$\|^\s*$', 'bnW') + 1
+  let l:start_line = search('^\s*$', 'bnW') + 1
   if l:start_line == 1 && getline(1) =~ '^\s*$'
     let l:start_line = search('^\S', 'nW')
   endif

--- a/doc/send_to_ai_cli.txt
+++ b/doc/send_to_ai_cli.txt
@@ -99,6 +99,10 @@ Example: >
 :AiCliSendCurrentLine
     Send the current line to AI CLI.
 
+                                                      *:AiCliSendParagraph*
+:AiCliSendParagraph
+    Send the current paragraph to AI CLI.
+
 ==============================================================================
 6. MAPPINGS                                        *send-to-ai-cli-mappings*
 
@@ -114,6 +118,7 @@ Plug mappings for custom configuration:
     <Plug>(send-to-ai-cli-buffer)    Send entire buffer
     <Plug>(send-to-ai-cli-visual)    Send visual selection
     <Plug>(send-to-ai-cli-current-line) Send current line
+    <Plug>(send-to-ai-cli-paragraph) Send current paragraph
 
 ==============================================================================
 7. LIMITATIONS                                    *send-to-ai-cli-limitations*
@@ -131,6 +136,8 @@ Custom mappings: >
     nmap <Leader>ay <Plug>(send-to-ai-cli-yanked)
     nmap <Leader>ab <Plug>(send-to-ai-cli-buffer)
     vmap <Leader>av <Plug>(send-to-ai-cli-visual)
+    nmap <Leader>al <Plug>(send-to-ai-cli-current-line)
+    nmap <Leader>ap <Plug>(send-to-ai-cli-paragraph)
 <
 
 Fallback target configuration: >

--- a/plugin/send_to_ai_cli.vim
+++ b/plugin/send_to_ai_cli.vim
@@ -28,9 +28,11 @@ command! -nargs=0 AiCliSendYanked call send_to_ai_cli#send_yanked()
 command! -nargs=0 AiCliSendBuffer call send_to_ai_cli#send_buffer()
 command! -range AiCliSendRange <line1>,<line2>call send_to_ai_cli#send_range()
 command! -nargs=0 AiCliSendCurrentLine call send_to_ai_cli#send_current_line()
+command! -nargs=0 AiCliSendParagraph call send_to_ai_cli#send_paragraph()
 
 nnoremap <Plug>(send-to-ai-cli-yanked) <Cmd>call send_to_ai_cli#send_yanked()<CR>
 nnoremap <Plug>(send-to-ai-cli-buffer) <Cmd>call send_to_ai_cli#send_buffer()<CR>
 vnoremap <Plug>(send-to-ai-cli-visual) :<C-u>call send_to_ai_cli#send_visual()<CR>
 nnoremap <Plug>(send-to-ai-cli-current-line) <Cmd>call send_to_ai_cli#send_current_line()<CR>
+nnoremap <Plug>(send-to-ai-cli-paragraph) <Cmd>call send_to_ai_cli#send_paragraph()<CR>
 


### PR DESCRIPTION
## Issue

- Closes: #8 

## Implementation Details

### Added Feature

Added functionality to send the current paragraph to AI CLI.

### Changes

1. **autoload/send_to_ai_cli.vim**
   - Added `send_to_ai_cli#send_paragraph()` function
   - Implemented paragraph boundary detection and sending functionality

2. **plugin/send_to_ai_cli.vim**
   - Added `:AiCliSendParagraph` command
   - Added `<Plug>(send-to-ai-cli-paragraph)` mapping

3. **README.md**
   - Added new feature to Features section
   - Added `<Leader>ap` to Key Mappings examples
   - Added new command to Commands section

4. **doc/send_to_ai_cli.txt**
   - Added documentation for `:AiCliSendParagraph` command
   - Added plug mapping documentation
   - Updated Examples section

### Usage

```vim
" Example key mapping
nmap <Leader>ap <Plug>(send-to-ai-cli-paragraph)
```

Or execute the command directly:

```vim
:AiCliSendParagraph
```