### PR TITLE
feat: Search AI CLI pane in entire tmux session

### DIFF
--- a/autoload/send_to_ai_cli.vim
+++ b/autoload/send_to_ai_cli.vim
@@ -118,9 +118,9 @@ function! s:send_text_to_ai_cli(text) abort
   call system(l:enter_cmd)
 endfunction
 
-function! s:find_ai_cli_pane() abort
-  " First, try to find in current window
-  let l:panes_output = system('tmux list-panes -F "#{pane_pid} #{pane_id}"')
+function! s:get_tmux_pane_map(tmux_flags) abort
+  let l:cmd = 'tmux list-panes ' . a:tmux_flags . ' -F "#{pane_pid} #{pane_id}"'
+  let l:panes_output = system(l:cmd)
   let l:pane_map = {}
   for l:line in split(l:panes_output, "\n")
     let l:parts = split(l:line)
@@ -128,65 +128,54 @@ function! s:find_ai_cli_pane() abort
       let l:pane_map[l:parts[0]] = l:parts[1]
     endif
   endfor
+  return l:pane_map
+endfunction
 
+function! s:find_ai_cli_in_panes(pane_map, ps_output, process_names) abort
+  for l:line in split(a:ps_output, "\n")
+    let l:found_process = 0
+    for l:name in a:process_names
+      if l:line =~# l:name && l:line !~# 'grep'
+        let l:found_process = 1
+        break
+      endif
+    endfor
+
+    if l:found_process
+      let l:parts = split(l:line)
+      if len(l:parts) >= 1
+        let l:ppid = l:parts[0]
+        if has_key(a:pane_map, l:ppid)
+          return a:pane_map[l:ppid]
+        endif
+      endif
+    endif
+  endfor
+  return ''
+endfunction
+
+function! s:find_ai_cli_pane() abort
+  " Get process info once for both searches
   let l:ps_output = system('ps -ax -o ppid,command')
   let l:process_names = get(g:, 'ai_cli_process_names', ['claude', 'gemini'])
 
-  " Check processes against current window panes
-  for l:line in split(l:ps_output, "\n")
-    let l:found_process = 0
-    for l:name in l:process_names
-      if l:line =~# l:name && l:line !~# 'grep'
-        let l:found_process = 1
-        break
-      endif
-    endfor
-
-    if l:found_process
-      let l:parts = split(l:line)
-      if len(l:parts) >= 1
-        let l:ppid = l:parts[0]
-        if has_key(l:pane_map, l:ppid)
-          return l:pane_map[l:ppid]
-        endif
-      endif
-    endif
-  endfor
+  " First, try to find in current window
+  let l:pane_map = s:get_tmux_pane_map('')
+  let l:result = s:find_ai_cli_in_panes(l:pane_map, l:ps_output, l:process_names)
+  if !empty(l:result)
+    return l:result
+  endif
 
   " If not found in current window, search in entire session
-  let l:panes_output = system('tmux list-panes -s -F "#{pane_pid} #{pane_id}"')
-  let l:pane_map = {}
-  for l:line in split(l:panes_output, "\n")
-    let l:parts = split(l:line)
-    if len(l:parts) >= 2
-      let l:pane_map[l:parts[0]] = l:parts[1]
-    endif
-  endfor
-
+  let l:pane_map = s:get_tmux_pane_map('-s')
   if empty(l:pane_map)
     return get(g:, 'ai_cli_target', '')
   endif
-
-  " Check processes against session panes
-  for l:line in split(l:ps_output, "\n")
-    let l:found_process = 0
-    for l:name in l:process_names
-      if l:line =~# l:name && l:line !~# 'grep'
-        let l:found_process = 1
-        break
-      endif
-    endfor
-
-    if l:found_process
-      let l:parts = split(l:line)
-      if len(l:parts) >= 1
-        let l:ppid = l:parts[0]
-        if has_key(l:pane_map, l:ppid)
-          return l:pane_map[l:ppid]
-        endif
-      endif
-    endif
-  endfor
+  
+  let l:result = s:find_ai_cli_in_panes(l:pane_map, l:ps_output, l:process_names)
+  if !empty(l:result)
+    return l:result
+  endif
 
   return get(g:, 'ai_cli_target', '')
 endfunction


### PR DESCRIPTION
## Summary
- Added two-step search for AI CLI pane: first in current window, then in entire session
- Allows finding AI CLI processes running in different tmux windows

## Changes
- Modified `s:find_ai_cli_pane()` function to search current window first
- If not found in current window, searches entire tmux session using `-s` flag
- Updated error message from "current window" to "current session"

## Test plan
- [ ] Test with AI CLI in same tmux window
- [ ] Test with AI CLI in different tmux window but same session
- [ ] Test with no AI CLI running
- [ ] Verify all send commands work correctly (yanked, buffer, range, visual, line, paragraph)