### PR TITLE
feat: Enable selecting destinaton pane by number & fix documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ vmap <Leader>av <Plug>(tmux-send-to-ai-cli-visual)
 nmap <Leader>al <Plug>(tmux-send-to-ai-cli-current-line)
 nmap <Leader>ap <Plug>(tmux-send-to-ai-cli-paragraph)
 ```
+
+### Pane Selection
+
+You can send text to a specific pane by prefixing the mapping with a number:
+- `2<Leader>ay` - Send yanked text to pane 2
+- `<Leader>ay` - Auto-detect AI CLI pane (default)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # vim-tmux-send-to-ai-cli
 
-Send text from Vim to a tmux pane running following AI CLIs:
+Stop copying and pasting. Send Vim text directly to AI CLIs in tmux.
+
+Intelligent pane detection. No manual pane IDs or session names needed.
+
+Read [help](doc/tmux_send_to_ai_cli.txt) for details.
+
+## Features
+
+### Supported AI CLIs
 
 - Claude Code
 - Codex CLI
@@ -8,32 +16,16 @@ Send text from Vim to a tmux pane running following AI CLIs:
 - GitHub Copilot CLI
 - Additional CLIs can be configured (see `:help g:ai_cli_additional_processes`)
 
-The plugin auto-detects AI CLI panes in tmux - no manual configuration needed.
+### Send methods
 
-Read [help](doc/tmux_send_to_ai_cli.txt) for details.
+- Current line: Send the line where your cursor is
+- Current paragraph: Send the paragraph around your cursor
+- Visual selection: Send highlighted text
+- Entire buffer: Send the whole file you're editing
+- Yanked text: Send text from * register
+- Line ranges: Send specific lines (e.g., lines 10-20)
 
-## Installation
+### Target selection
 
-Using [vim-plug](https://github.com/junegunn/vim-plug):
-
-```vim
-Plug 'i9wa4/vim-tmux-send-to-ai-cli'
-```
-
-## Quick Start
-
-Add these mappings to your vimrc:
-
-```vim
-nmap <Leader>ay <Plug>(tmux-send-to-ai-cli-yanked)
-nmap <Leader>ab <Plug>(tmux-send-to-ai-cli-buffer)
-vmap <Leader>av <Plug>(tmux-send-to-ai-cli-visual)
-nmap <Leader>al <Plug>(tmux-send-to-ai-cli-current-line)
-nmap <Leader>ap <Plug>(tmux-send-to-ai-cli-paragraph)
-```
-
-### Pane Selection
-
-You can send text to a specific pane by prefixing the mapping with a number:
-- `2<Leader>ay` - Send yanked text to pane 2
-- `<Leader>ay` - Auto-detect AI CLI pane (default)
+- Auto-detection: Automatically finds AI CLI panes in tmux
+- Pane selection: Send to specific pane by number (e.g., 2<Leader>al for pane 2)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Send text from Vim to a tmux pane running following AI CLIs:
 - Claude Code
 - Codex CLI
 - Gemini CLI
+- GitHub Copilot CLI
 - Additional CLIs can be configured (see `:help g:ai_cli_additional_processes`)
 
 The plugin auto-detects AI CLI panes in tmux - no manual configuration needed.

--- a/doc/tmux_send_to_ai_cli.txt
+++ b/doc/tmux_send_to_ai_cli.txt
@@ -19,7 +19,14 @@ CONTENTS                                           *tmux-send-to-ai-cli-contents
 ==============================================================================
 1. INTRODUCTION                                *tmux-send-to-ai-cli-introduction*
 
-Send text from Vim to a tmux pane running following AI CLIs:
+Stop copying and pasting. Send Vim text directly to AI CLIs in tmux.
+
+Intelligent pane detection. No manual pane IDs or session names needed.
+
+==============================================================================
+2. FEATURES                                        *tmux-send-to-ai-cli-features*
+
+Supported AI CLIs:
 
 - Claude Code
 - Codex CLI
@@ -27,21 +34,19 @@ Send text from Vim to a tmux pane running following AI CLIs:
 - GitHub Copilot CLI
 - Additional CLIs can be configured (see |g:ai_cli_additional_processes|)
 
-The plugin auto-detects AI CLI panes in tmux - no manual configuration needed.
+Send methods:
 
-==============================================================================
-2. FEATURES                                        *tmux-send-to-ai-cli-features*
+- Current line: Send the line where your cursor is
+- Current paragraph: Send the paragraph around your cursor
+- Visual selection: Send highlighted text
+- Entire buffer: Send the whole file you're editing
+- Yanked text: Send text from * register
+- Line ranges: Send specific lines (e.g., lines 10-20)
 
-Send code or text from Vim directly to your AI assistant:
+Target selection:
 
-- Yanked text - Send text from Vim registers
-- Entire buffer - Send the whole file you're editing
-- Visual selection - Send highlighted text
-- Line ranges - Send specific lines (e.g., lines 10-20)
-- Current line - Send the line where your cursor is
-- Current paragraph - Send the paragraph around your cursor
-- Auto-detection - Automatically finds AI CLI panes in tmux
-- Pane selection - Send to specific pane by number (e.g., 2<Leader>ay for pane 2)
+- Auto-detection: Automatically finds AI CLI panes in tmux
+- Pane selection: Send to specific pane by number (e.g., 2<Leader>ay for pane 2)
 
 ==============================================================================
 3. REQUIREMENTS                                *tmux-send-to-ai-cli-requirements*
@@ -56,7 +61,6 @@ Send code or text from Vim directly to your AI assistant:
 Using vim-plug: >
     Plug 'i9wa4/vim-tmux-send-to-ai-cli'
 <
-
 ==============================================================================
 5. CONFIGURATION                              *tmux-send-to-ai-cli-configuration*
 
@@ -114,16 +118,17 @@ Example: >
 
 Plug mappings for custom configuration:
 
-    <Plug>(tmux-send-to-ai-cli-yanked)          Send yanked text
-    <Plug>(tmux-send-to-ai-cli-buffer)          Send entire buffer
-    <Plug>(tmux-send-to-ai-cli-visual)          Send visual selection
     <Plug>(tmux-send-to-ai-cli-current-line)    Send current line
     <Plug>(tmux-send-to-ai-cli-paragraph)       Send current paragraph
+    <Plug>(tmux-send-to-ai-cli-visual)          Send visual selection
+    <Plug>(tmux-send-to-ai-cli-buffer)          Send entire buffer
+    <Plug>(tmux-send-to-ai-cli-yanked)          Send yanked text
 
 Pane selection: >
-    2<Leader>ay    Send yanked text to pane 2
-    <Leader>ay     Auto-detect AI CLI pane (default)
+    2<Leader>al    Send current line to pane 2
+    <Leader>al     Auto-detect AI CLI pane (default)
 <
+
 You can send text to a specific pane by prefixing the mapping with a number.
 
 ==============================================================================
@@ -140,11 +145,11 @@ You can send text to a specific pane by prefixing the mapping with a number.
 9. EXAMPLES                                        *tmux-send-to-ai-cli-examples*
 
 Custom mappings: >
-    nmap <Leader>ay <Plug>(tmux-send-to-ai-cli-yanked)
-    nmap <Leader>ab <Plug>(tmux-send-to-ai-cli-buffer)
-    vmap <Leader>av <Plug>(tmux-send-to-ai-cli-visual)
     nmap <Leader>al <Plug>(tmux-send-to-ai-cli-current-line)
     nmap <Leader>ap <Plug>(tmux-send-to-ai-cli-paragraph)
+    vmap <Leader>av <Plug>(tmux-send-to-ai-cli-visual)
+    nmap <Leader>ab <Plug>(tmux-send-to-ai-cli-buffer)
+    nmap <Leader>ay <Plug>(tmux-send-to-ai-cli-yanked)
 <
 
 Fallback target configuration: >

--- a/doc/tmux_send_to_ai_cli.txt
+++ b/doc/tmux_send_to_ai_cli.txt
@@ -41,6 +41,7 @@ Send code or text from Vim directly to your AI assistant:
 - Current line - Send the line where your cursor is
 - Current paragraph - Send the paragraph around your cursor
 - Auto-detection - Automatically finds AI CLI panes in tmux
+- Pane selection - Send to specific pane by number (e.g., 2<Leader>ay for pane 2)
 
 ==============================================================================
 3. REQUIREMENTS                                *tmux-send-to-ai-cli-requirements*
@@ -118,6 +119,12 @@ Plug mappings for custom configuration:
     <Plug>(tmux-send-to-ai-cli-visual)          Send visual selection
     <Plug>(tmux-send-to-ai-cli-current-line)    Send current line
     <Plug>(tmux-send-to-ai-cli-paragraph)       Send current paragraph
+
+Pane selection: >
+    2<Leader>ay    Send yanked text to pane 2
+    <Leader>ay     Auto-detect AI CLI pane (default)
+<
+You can send text to a specific pane by prefixing the mapping with a number.
 
 ==============================================================================
 8. LIMITATIONS                                    *tmux-send-to-ai-cli-limitations*

--- a/doc/tmux_send_to_ai_cli.txt
+++ b/doc/tmux_send_to_ai_cli.txt
@@ -7,33 +7,30 @@ License: MIT
 CONTENTS                                           *tmux-send-to-ai-cli-contents*
 
     1. Introduction .................. |tmux-send-to-ai-cli-introduction|
-    2. Supported AI CLIs ............. |tmux-send-to-ai-cli-supported|
-    3. Features ...................... |tmux-send-to-ai-cli-features|
-    4. Requirements .................. |tmux-send-to-ai-cli-requirements|
-    5. Installation .................. |tmux-send-to-ai-cli-installation|
-    6. Configuration ................. |tmux-send-to-ai-cli-configuration|
-    7. Commands ...................... |tmux-send-to-ai-cli-commands|
-    8. Mappings ...................... |tmux-send-to-ai-cli-mappings|
-    9. Limitations ................... |tmux-send-to-ai-cli-limitations|
-   10. Examples ...................... |tmux-send-to-ai-cli-examples|
+    2. Features ...................... |tmux-send-to-ai-cli-features|
+    3. Requirements .................. |tmux-send-to-ai-cli-requirements|
+    4. Installation .................. |tmux-send-to-ai-cli-installation|
+    5. Configuration ................. |tmux-send-to-ai-cli-configuration|
+    6. Commands ...................... |tmux-send-to-ai-cli-commands|
+    7. Mappings ...................... |tmux-send-to-ai-cli-mappings|
+    8. Limitations ................... |tmux-send-to-ai-cli-limitations|
+    9. Examples ...................... |tmux-send-to-ai-cli-examples|
 
 ==============================================================================
 1. INTRODUCTION                                *tmux-send-to-ai-cli-introduction*
 
-vim-tmux-send-to-ai-cli is a Vim plugin that allows you to send text
-from Vim to a tmux pane running AI CLI. This enables seamless integration
-between your text editor and AI assistant.
-
-==============================================================================
-2. SUPPORTED AI CLIS                              *tmux-send-to-ai-cli-supported*
+Send text from Vim to a tmux pane running following AI CLIs:
 
 - Claude Code
 - Codex CLI
 - Gemini CLI
+- GitHub Copilot CLI
 - Additional CLIs can be configured (see |g:ai_cli_additional_processes|)
 
+The plugin auto-detects AI CLI panes in tmux - no manual configuration needed.
+
 ==============================================================================
-3. FEATURES                                        *tmux-send-to-ai-cli-features*
+2. FEATURES                                        *tmux-send-to-ai-cli-features*
 
 Send code or text from Vim directly to your AI assistant:
 
@@ -46,29 +43,21 @@ Send code or text from Vim directly to your AI assistant:
 - Auto-detection - Automatically finds AI CLI panes in tmux
 
 ==============================================================================
-4. REQUIREMENTS                                *tmux-send-to-ai-cli-requirements*
+3. REQUIREMENTS                                *tmux-send-to-ai-cli-requirements*
 
 - Unix-like system (Linux, macOS, etc.)
 - tmux
 - AI CLI running in a tmux pane
 
 ==============================================================================
-5. INSTALLATION                                *tmux-send-to-ai-cli-installation*
+4. INSTALLATION                                *tmux-send-to-ai-cli-installation*
 
 Using vim-plug: >
     Plug 'i9wa4/vim-tmux-send-to-ai-cli'
 <
 
-Using Vundle: >
-    Plugin 'i9wa4/vim-tmux-send-to-ai-cli'
-<
-
-Using dein: >
-    call dein#add('i9wa4/vim-tmux-send-to-ai-cli')
-<
-
 ==============================================================================
-6. CONFIGURATION                              *tmux-send-to-ai-cli-configuration*
+5. CONFIGURATION                              *tmux-send-to-ai-cli-configuration*
 
                                             *g:ai_cli_additional_processes*
 g:ai_cli_additional_processes~
@@ -97,7 +86,7 @@ Example: >
 <
 
 ==============================================================================
-7. COMMANDS                                        *tmux-send-to-ai-cli-commands*
+6. COMMANDS                                        *tmux-send-to-ai-cli-commands*
 
                                                         *:AiCliSendYanked*
 :AiCliSendYanked
@@ -120,18 +109,18 @@ Example: >
     Send the current paragraph to AI CLI.
 
 ==============================================================================
-8. MAPPINGS                                        *tmux-send-to-ai-cli-mappings*
+7. MAPPINGS                                        *tmux-send-to-ai-cli-mappings*
 
 Plug mappings for custom configuration:
 
-    <Plug>(tmux-send-to-ai-cli-yanked)    Send yanked text
-    <Plug>(tmux-send-to-ai-cli-buffer)    Send entire buffer
-    <Plug>(tmux-send-to-ai-cli-visual)    Send visual selection
-    <Plug>(tmux-send-to-ai-cli-current-line) Send current line
-    <Plug>(tmux-send-to-ai-cli-paragraph) Send current paragraph
+    <Plug>(tmux-send-to-ai-cli-yanked)          Send yanked text
+    <Plug>(tmux-send-to-ai-cli-buffer)          Send entire buffer
+    <Plug>(tmux-send-to-ai-cli-visual)          Send visual selection
+    <Plug>(tmux-send-to-ai-cli-current-line)    Send current line
+    <Plug>(tmux-send-to-ai-cli-paragraph)       Send current paragraph
 
 ==============================================================================
-9. LIMITATIONS                                    *tmux-send-to-ai-cli-limitations*
+8. LIMITATIONS                                    *tmux-send-to-ai-cli-limitations*
 
 - The plugin searches for AI CLI panes in the current tmux session
   (prioritizing current window)
@@ -141,7 +130,7 @@ Plug mappings for custom configuration:
   configuration via g:ai_cli_target is required
 
 ==============================================================================
-10. EXAMPLES                                        *tmux-send-to-ai-cli-examples*
+9. EXAMPLES                                        *tmux-send-to-ai-cli-examples*
 
 Custom mappings: >
     nmap <Leader>ay <Plug>(tmux-send-to-ai-cli-yanked)

--- a/plugin/tmux_send_to_ai_cli.vim
+++ b/plugin/tmux_send_to_ai_cli.vim
@@ -24,15 +24,15 @@ endif
 
 let g:ai_cli_target = get(g:, 'ai_cli_target', '')
 
-command! -nargs=0 AiCliSendYanked call tmux_send_to_ai_cli#send_yanked()
-command! -nargs=0 AiCliSendBuffer call tmux_send_to_ai_cli#send_buffer()
-command! -range AiCliSendRange <line1>,<line2>call tmux_send_to_ai_cli#send_range()
-command! -nargs=0 AiCliSendCurrentLine call tmux_send_to_ai_cli#send_current_line()
-command! -nargs=0 AiCliSendParagraph call tmux_send_to_ai_cli#send_paragraph()
+command! -nargs=0 AiCliSendYanked call tmux_send_to_ai_cli#send_yanked(1)
+command! -nargs=0 AiCliSendBuffer call tmux_send_to_ai_cli#send_buffer(1)
+command! -range AiCliSendRange <line1>,<line2>call tmux_send_to_ai_cli#send_range(1)
+command! -nargs=0 AiCliSendCurrentLine call tmux_send_to_ai_cli#send_current_line(1)
+command! -nargs=0 AiCliSendParagraph call tmux_send_to_ai_cli#send_paragraph(1)
 
-nnoremap <Plug>(tmux-send-to-ai-cli-yanked) <Cmd>call tmux_send_to_ai_cli#send_yanked()<CR>
-nnoremap <Plug>(tmux-send-to-ai-cli-buffer) <Cmd>call tmux_send_to_ai_cli#send_buffer()<CR>
-vnoremap <Plug>(tmux-send-to-ai-cli-visual) :<C-u>call tmux_send_to_ai_cli#send_visual()<CR>
-nnoremap <Plug>(tmux-send-to-ai-cli-current-line) <Cmd>call tmux_send_to_ai_cli#send_current_line()<CR>
-nnoremap <Plug>(tmux-send-to-ai-cli-paragraph) <Cmd>call tmux_send_to_ai_cli#send_paragraph()<CR>
+nnoremap <Plug>(tmux-send-to-ai-cli-yanked) <Cmd>call tmux_send_to_ai_cli#send_yanked(v:count1)<CR>
+nnoremap <Plug>(tmux-send-to-ai-cli-buffer) <Cmd>call tmux_send_to_ai_cli#send_buffer(v:count1)<CR>
+vnoremap <Plug>(tmux-send-to-ai-cli-visual) :<C-u>call tmux_send_to_ai_cli#send_visual(v:count1)<CR>
+nnoremap <Plug>(tmux-send-to-ai-cli-current-line) <Cmd>call tmux_send_to_ai_cli#send_current_line(v:count1)<CR>
+nnoremap <Plug>(tmux-send-to-ai-cli-paragraph) <Cmd>call tmux_send_to_ai_cli#send_paragraph(v:count1)<CR>
 


### PR DESCRIPTION
Add support for specifying tmux pane by number with count prefix

## Summary

- Users can now send text to a specific pane by prefixing mappings with a number
- Example: 2<Leader>ay sends yanked text to pane 2
- Without a count, the plugin maintains existing auto-detection behavior

## Background

Previously, the plugin only supported auto-detection of AI CLI panes. This enhancement allows users to explicitly specify which pane to send text to within the same tmux window, providing more control over text routing.

## Changes

- Added count parameter to all public functions in autoload/tmux_send_to_ai_cli.vim
- Modified plugin mappings to pass v:count1 for pane selection
- Implemented s:get_target_pane() function to handle count-based pane selection
- Updated documentation to explain the new pane selection feature
- Added "Pane selection" to the Features section in documentation

## Technical Details

The implementation uses Vim's built-in count mechanism (v:count1) which automatically captures numeric input before key mappings. When a count greater than 1 is provided, it's used as the tmux pane index. The function s:get_target_pane() determines whether to use the count as a pane index or fall back to auto-detection.

Design decision: Using v:count1 instead of v:count ensures backward compatibility, as v:count1 defaults to 1 when no count is provided, allowing the existing auto-detection logic to work seamlessly.

## Testing

Manual testing confirmed:
- Standard mappings (e.g., <Leader>ay) continue to auto-detect AI CLI panes
- Count-prefixed mappings (e.g., 2<Leader>ay) correctly send to specified pane
- Error messages appropriately display when specified pane doesn't exist

## Related URLs

- Closes: #13 