### PR TITLE
feat: Remove send yanked text functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Read [help](doc/tmux_send_to_ai_cli.txt) for details.
 - Current paragraph: Send the paragraph around your cursor
 - Visual selection: Send highlighted text
 - Entire buffer: Send the whole file you're editing
-- Yanked text: Send text from * register
 - Line ranges: Send specific lines (e.g., lines 10-20)
 
 ### Target selection

--- a/autoload/tmux_send_to_ai_cli.vim
+++ b/autoload/tmux_send_to_ai_cli.vim
@@ -1,19 +1,6 @@
 " Default supported AI CLI processes
-" Note: 'copilot' matches both GitHub Copilot CLI and other copilot commands
+" NOTE: 'copilot' matches both GitHub Copilot CLI and other copilot commands
 let s:DEFAULT_AI_CLIS = ['claude', 'codex', 'copilot', 'gemini']
-
-function! tmux_send_to_ai_cli#send_yanked(...) abort
-  let l:text = getreg('*')
-  if empty(l:text)
-    echo "No yanked text found in * register"
-    return
-  endif
-
-  let l:count = a:0 >= 1 ? a:1 : 0
-  let l:explicit = a:0 >= 2 ? a:2 : 0
-  call s:send_text_to_ai_cli(l:text, l:count, l:explicit)
-  echo "Sent yanked text to AI CLI"
-endfunction
 
 function! tmux_send_to_ai_cli#send_buffer(...) abort
   let l:text = join(getline(1, '$'), "\n")

--- a/doc/tmux_send_to_ai_cli.txt
+++ b/doc/tmux_send_to_ai_cli.txt
@@ -93,10 +93,6 @@ Example: >
 ==============================================================================
 6. COMMANDS                                        *tmux-send-to-ai-cli-commands*
 
-                                                        *:AiCliSendYanked*
-:AiCliSendYanked
-    Send the content of the * register (yanked text) to AI CLI.
-
                                                         *:AiCliSendBuffer*
 :AiCliSendBuffer
     Send the entire current buffer to AI CLI.
@@ -122,7 +118,6 @@ Plug mappings for custom configuration:
     <Plug>(tmux-send-to-ai-cli-paragraph)       Send current paragraph
     <Plug>(tmux-send-to-ai-cli-visual)          Send visual selection
     <Plug>(tmux-send-to-ai-cli-buffer)          Send entire buffer
-    <Plug>(tmux-send-to-ai-cli-yanked)          Send yanked text
 
 Pane selection: >
     2<Leader>al    Send current line to pane 2
@@ -149,7 +144,6 @@ Custom mappings: >
     nmap <Leader>ap <Plug>(tmux-send-to-ai-cli-paragraph)
     vmap <Leader>av <Plug>(tmux-send-to-ai-cli-visual)
     nmap <Leader>ab <Plug>(tmux-send-to-ai-cli-buffer)
-    nmap <Leader>ay <Plug>(tmux-send-to-ai-cli-yanked)
 <
 
 Fallback target configuration: >

--- a/plugin/tmux_send_to_ai_cli.vim
+++ b/plugin/tmux_send_to_ai_cli.vim
@@ -24,13 +24,11 @@ endif
 
 let g:ai_cli_target = get(g:, 'ai_cli_target', '')
 
-command! -nargs=0 AiCliSendYanked call tmux_send_to_ai_cli#send_yanked()
 command! -nargs=0 AiCliSendBuffer call tmux_send_to_ai_cli#send_buffer()
 command! -range AiCliSendRange <line1>,<line2>call tmux_send_to_ai_cli#send_range()
 command! -nargs=0 AiCliSendCurrentLine call tmux_send_to_ai_cli#send_current_line()
 command! -nargs=0 AiCliSendParagraph call tmux_send_to_ai_cli#send_paragraph()
 
-nnoremap <Plug>(tmux-send-to-ai-cli-yanked) <Cmd>call tmux_send_to_ai_cli#send_yanked(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
 nnoremap <Plug>(tmux-send-to-ai-cli-buffer) <Cmd>call tmux_send_to_ai_cli#send_buffer(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
 vnoremap <Plug>(tmux-send-to-ai-cli-visual) :<C-u>call tmux_send_to_ai_cli#send_visual(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
 nnoremap <Plug>(tmux-send-to-ai-cli-current-line) <Cmd>call tmux_send_to_ai_cli#send_current_line(v:count ? v:count : 0, v:count ? 1 : 0)<CR>


### PR DESCRIPTION
Simplify plugin by removing rarely used feature with cross-editor compatibility issues

## Summary

- Removed send_yanked() function and all related code
- Eliminates Vim/Neovim register specification differences
- Reduces maintenance burden for rarely used feature

## Background

The "send yanked text" feature had compatibility issues between Vim and Neovim due to different register specifications. Given its low usage frequency and the maintenance complexity it introduced, removing this feature simplifies the plugin while maintaining all commonly used functionality.

## Changes

- Removed `tmux_send_to_ai_cli#send_yanked()` function from autoload
- Removed `:AiCliSendYanked` command from plugin
- Removed `<Plug>(tmux-send-to-ai-cli-yanked)` mapping
- Updated documentation to remove all yanked text references
- Cleaned up README.md send methods list

## Technical Details

The removal was straightforward as the yanked text functionality was self-contained with no dependencies from other features. All other send methods (buffer, visual, current line, paragraph, range) remain fully functional.

The function used the `*` register which behaves differently between Vim and Neovim, particularly around clipboard integration, making consistent behavior difficult to maintain.

## Testing

- Verified all yanked-related code has been removed
- Confirmed other send functions continue to work correctly
- Checked documentation consistency

## Related URLs

- Closes #14