### PR TITLE
feat: add support for sending text to all AI CLI panes at once (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Additional CLIs can be configured (see `:help g:tmux_ai_cli_additional_processes
   - Searches panes in pane index order (0, 1, 2...)
   - Returns the first matching AI CLI pane
 - **Pane selection**: Send to specific pane by number in current window
+- **All panes**: Send to all AI CLI panes at once in current window

--- a/doc/tmux_send_to_ai_cli.txt
+++ b/doc/tmux_send_to_ai_cli.txt
@@ -49,6 +49,7 @@ Target selection:
     - Searches panes in pane index order (0, 1, 2...)
     - Returns the first matching AI CLI pane
 - Pane selection: Send to specific pane by number in current window
+- All panes: Send to all AI CLI panes at once in current window
 
 ==============================================================================
 3. REQUIREMENTS                                *tmux-send-to-ai-cli-requirements*
@@ -97,15 +98,36 @@ Example: >
 :AiCliSendParagraph
     Send the current paragraph to AI CLI.
 
+                                                     *:AiCliSendBufferAll*
+:AiCliSendBufferAll
+    Send the entire current buffer to all AI CLI panes in current window.
+
+                                                      *:AiCliSendRangeAll*
+:[range]AiCliSendRangeAll
+    Send the specified range of lines to all AI CLI panes in current window.
+
+                                                 *:AiCliSendCurrentLineAll*
+:AiCliSendCurrentLineAll
+    Send the current line to all AI CLI panes in current window.
+
+                                                   *:AiCliSendParagraphAll*
+:AiCliSendParagraphAll
+    Send the current paragraph to all AI CLI panes in current window.
+
 ==============================================================================
 7. MAPPINGS                                        *tmux-send-to-ai-cli-mappings*
 
 Plug mappings for custom configuration:
 
-    <Plug>(tmux-send-to-ai-cli-current-line)    Send current line
-    <Plug>(tmux-send-to-ai-cli-paragraph)       Send current paragraph
-    <Plug>(tmux-send-to-ai-cli-visual)          Send visual selection
-    <Plug>(tmux-send-to-ai-cli-buffer)          Send entire buffer
+    <Plug>(tmux-send-to-ai-cli-current-line)        Send current line
+    <Plug>(tmux-send-to-ai-cli-paragraph)           Send current paragraph
+    <Plug>(tmux-send-to-ai-cli-visual)              Send visual selection
+    <Plug>(tmux-send-to-ai-cli-buffer)              Send entire buffer
+
+    <Plug>(tmux-send-to-ai-cli-current-line-all)    Send current line to all panes
+    <Plug>(tmux-send-to-ai-cli-paragraph-all)       Send current paragraph to all panes
+    <Plug>(tmux-send-to-ai-cli-visual-all)          Send visual selection to all panes
+    <Plug>(tmux-send-to-ai-cli-buffer-all)          Send entire buffer to all panes
 
 You can send text to a specific pane by prefixing the mapping with a number.
 
@@ -128,8 +150,20 @@ Custom mappings: >
     nmap <Leader>ab <Plug>(tmux-send-to-ai-cli-buffer)
 <
 
+Custom mappings for all panes: >
+    nmap <Leader>aL <Plug>(tmux-send-to-ai-cli-current-line-all)
+    nmap <Leader>aP <Plug>(tmux-send-to-ai-cli-paragraph-all)
+    vmap <Leader>aV <Plug>(tmux-send-to-ai-cli-visual-all)
+    nmap <Leader>aB <Plug>(tmux-send-to-ai-cli-buffer-all)
+<
+
 Send specific lines: >
     :10,20AiCliSendRange
+<
+
+Send to all panes: >
+    :AiCliSendBufferAll
+    :10,20AiCliSendRangeAll
 <
 
 ==============================================================================

--- a/plugin/tmux_send_to_ai_cli.vim
+++ b/plugin/tmux_send_to_ai_cli.vim
@@ -8,7 +8,17 @@ command! -range AiCliSendRange <line1>,<line2>call tmux_send_to_ai_cli#send_rang
 command! -nargs=0 AiCliSendCurrentLine call tmux_send_to_ai_cli#send_current_line()
 command! -nargs=0 AiCliSendParagraph call tmux_send_to_ai_cli#send_paragraph()
 
+command! -nargs=0 AiCliSendBufferAll call tmux_send_to_ai_cli#send_buffer(0, 0, 1)
+command! -range AiCliSendRangeAll <line1>,<line2>call tmux_send_to_ai_cli#send_range(0, 0, 1)
+command! -nargs=0 AiCliSendCurrentLineAll call tmux_send_to_ai_cli#send_current_line(0, 0, 1)
+command! -nargs=0 AiCliSendParagraphAll call tmux_send_to_ai_cli#send_paragraph(0, 0, 1)
+
 nnoremap <Plug>(tmux-send-to-ai-cli-buffer) <Cmd>call tmux_send_to_ai_cli#send_buffer(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
 vnoremap <Plug>(tmux-send-to-ai-cli-visual) :<C-u>call tmux_send_to_ai_cli#send_visual(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
 nnoremap <Plug>(tmux-send-to-ai-cli-current-line) <Cmd>call tmux_send_to_ai_cli#send_current_line(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
 nnoremap <Plug>(tmux-send-to-ai-cli-paragraph) <Cmd>call tmux_send_to_ai_cli#send_paragraph(v:count ? v:count : 0, v:count ? 1 : 0)<CR>
+
+nnoremap <Plug>(tmux-send-to-ai-cli-buffer-all) <Cmd>call tmux_send_to_ai_cli#send_buffer(0, 0, 1)<CR>
+vnoremap <Plug>(tmux-send-to-ai-cli-visual-all) :<C-u>call tmux_send_to_ai_cli#send_visual(0, 0, 1)<CR>
+nnoremap <Plug>(tmux-send-to-ai-cli-current-line-all) <Cmd>call tmux_send_to_ai_cli#send_current_line(0, 0, 1)<CR>
+nnoremap <Plug>(tmux-send-to-ai-cli-paragraph-all) <Cmd>call tmux_send_to_ai_cli#send_paragraph(0, 0, 1)<CR>


### PR DESCRIPTION
Enable sending text to all AI CLI panes simultaneously in the current tmux window.

## Overview

This commit implements the ability to send text to multiple AI CLI panes at once, allowing users to compare responses from different AI tools (Claude, Codex, Copilot, Gemini) simultaneously.

## Background

Previously, the plugin could only send text to a single AI CLI pane at a time. When multiple AI CLI panes existed in the same window, only the first one was targeted. This limitation prevented efficient comparison of different AI tools.

## Changes

- Added `s:find_all_ai_cli_panes()` function to detect all AI CLI panes
- Extended `s:send_text_to_ai_cli()` to support multiple pane sending (count=-1)
- Added optional `send_all` parameter to all public functions
- Added new commands: `AiCliSendBufferAll`, `AiCliSendRangeAll`, `AiCliSendCurrentLineAll`, `AiCliSendParagraphAll`
- Added new Plug mappings: `<Plug>(tmux-send-to-ai-cli-{buffer,visual,current-line,paragraph}-all)`
- Updated documentation (Features, Commands, Mappings, Examples sections)
- Updated README.md with "All panes" target selection feature

## Technical Details

- Used `count=-1` as a special value to trigger all-panes mode
- Implemented best-effort sending: continues even if some panes fail
- Success/failure counts are displayed to the user
- Maintains backward compatibility: default behavior unchanged
- Public function signature: `send_buffer(count, explicit, send_all=0)`

## Verification

Implementation completed with 174 line additions (+170) across 4 files:
- autoload/tmux_send_to_ai_cli.vim: +125 lines
- plugin/tmux_send_to_ai_cli.vim: +10 lines
- doc/tmux_send_to_ai_cli.txt: +42 lines (-4 lines)
- README.md: +1 line

## Related URLs

- https://github.com/i9wa4/vim-tmux-send-to-ai-cli/issues/21
